### PR TITLE
fix: properly handle releases with multiple npm tags

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -446,7 +446,7 @@ Each release contains all the data returned by the
 plus some extra properties:
 
 - `version` (String) - the same thing as `dist_tag`, but without the `v` for convenient [semver comparisons](https://github.com/npm/node-semver#usage).
-- `npm_dist_tag` (String) - an [npm dist-tag](https://docs.npmjs.com/cli/dist-tag) like `latest` or `beta`. Most releases will not have this property.
+- `npm_dist_tags` (Array<String>) - an array of [npm dist-tags](https://docs.npmjs.com/cli/dist-tag) like `"latest"` or `"beta"`. Most releases will have an empty array for this property.
 - `npm_package_name` (String) - For packages published to npm, this will be `electron` or `electron-prebuilt`. For packages not published to npm, this property will not exist.
 - `total_downloads` (Number) - Total downloads of all assets in the release that
   have a [detectable platform](https://github.com/zeke/platform-utils#api) in their

--- a/script/collect.js
+++ b/script/collect.js
@@ -42,9 +42,10 @@ async function main () {
   const npmDistTaggedVersions = Object.keys(distTags)
     .reduce((acc, key) => {
       if (!acc[distTags[key]]) {
-        acc[distTags[key]] = []
+        acc[distTags[key]] = [key]
+      } else {
+        acc[distTags[key]].push(key)
       }
-      acc[distTags[key]].push(key)
       return acc
     }, {})
 

--- a/script/collect.js
+++ b/script/collect.js
@@ -97,10 +97,11 @@ async function main () {
   releases = await Promise.all(releases.map(processRelease))
 
   // Compare the old data to the new data
-  // and abort the build early if key data hasn't changed
+  // and abort the build early if key data hasn't changed.
   const old = require('..')
   // Convert the 2.x npm_dist_tag (string) format to the
-  // 3.x npm_dist_tags (array) format
+  // 3.x npm_dist_tags (array) format.
+  // This can be removed once a 3.x release is published.
   old.forEach(release => {
     if (release.npm_dist_tag) {
       release.npm_dist_tags = [release.npm_dist_tag]

--- a/script/collect.js
+++ b/script/collect.js
@@ -76,8 +76,7 @@ async function main () {
       if (deps) release.deps = deps
 
       // apply dist tags from npm (usually `latest`, `beta` or `nightly`)
-      const npmDistTags = npmDistTaggedVersions[release.version] || []
-      release.npm_dist_tags = npmDistTags
+      release.npm_dist_tags = npmDistTaggedVersions[release.version] || []
 
       if (release.assets) {
         release.total_downloads = release.assets

--- a/script/collect.js
+++ b/script/collect.js
@@ -41,7 +41,10 @@ async function main () {
   const distTags = npmElectronData.body['dist-tags']
   const npmDistTaggedVersions = Object.keys(distTags)
     .reduce((acc, key) => {
-      acc[distTags[key]] = key
+      if (!acc[distTags[key]]) {
+        acc[distTags[key]] = []
+      }
+      acc[distTags[key]].push(key)
       return acc
     }, {})
 
@@ -72,8 +75,8 @@ async function main () {
       if (deps) release.deps = deps
 
       // apply dist tags from npm (usually `latest`, `beta` or `nightly`)
-      const npmDistTag = npmDistTaggedVersions[release.version]
-      if (npmDistTag) release.npm_dist_tag = npmDistTag
+      const npmDistTags = npmDistTaggedVersions[release.version] || []
+      release.npm_dist_tags = npmDistTags
 
       if (release.assets) {
         release.total_downloads = release.assets
@@ -93,12 +96,21 @@ async function main () {
   console.log('processing changelogs to HTML')
   releases = await Promise.all(releases.map(processRelease))
 
-  // Abort the build early if module is already up to date
+  // Compare the old data to the new data
+  // and abort the build early if key data hasn't changed
   const old = require('..')
-  const oldLatest = old.find(release => release.npm_dist_tag === 'latest').version
-  const newLatest = releases.find(release => release.npm_dist_tag === 'latest').version
-  const oldBeta = old.find(release => release.npm_dist_tag === 'beta').version
-  const newBeta = releases.find(release => release.npm_dist_tag === 'beta').version
+  // Convert the 2.x npm_dist_tag (string) format to the
+  // 3.x npm_dist_tags (array) format
+  old.forEach(release => {
+    if (release.npm_dist_tag) {
+      release.npm_dist_tags = [release.npm_dist_tag]
+      delete release.npm_dist_tag
+    }
+  })
+  const oldLatest = old.find(hasNpmDistTag('latest')).version
+  const newLatest = releases.find(hasNpmDistTag('latest')).version
+  const oldBeta = old.find(hasNpmDistTag('beta')).version
+  const newBeta = releases.find(hasNpmDistTag('beta')).version
   const oldNpmCount = old.filter(release => release.npm_package_name === 'electron').length
   const newNpmCount = releases.filter(release => release.npm_package_name === 'electron').length
 
@@ -124,6 +136,16 @@ async function main () {
 }
 
 // helpers
+
+function hasNpmDistTag (tag) {
+  return function (release) {
+    if (!release.npm_dist_tags) {
+      return false
+    }
+
+    return release.npm_dist_tags.includes(tag)
+  }
+}
 
 async function processRelease (release) {
   release.version = release.tag_name.substring(1)


### PR DESCRIPTION
In some cases, a release has multiple npm distribution tags (e.g., `v3.0.8` might be tagged as `latest` and also `3-0-x`). In this case, we want the script to favor the `latest` tag.

This will break if a release has multiple priority tags (e.g. a release is tagged as `latest` and also `beta`) but I'm pretty sure that should never happen. 🤞 