### PR TITLE
feat: pull nightlies correctly from new package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: node_js
 node_js:
   - '8'
   - '10'
+install:
+  - npm ci
+script:
+  - npm run build && npm test

--- a/test/index.js
+++ b/test/index.js
@@ -48,13 +48,18 @@ describe('electron-releases', () => {
   })
 
   it('includes one release with the `beta` npm dist tag', () => {
-    const betas = releases.filter(release => release.npm_dist_tags.includes('beta'))
-    betas.length.should.eq(1)
+    const beta = releases.filter(release => release.npm_dist_tags.includes('beta'))
+    beta.length.should.eq(1)
   })
 
   it('includes one release with the `latest` npm dist tag', () => {
-    const latests = releases.filter(release => release.npm_dist_tags.includes('latest'))
-    latests.length.should.eq(1)
+    const latest = releases.filter(release => release.npm_dist_tags.includes('latest'))
+    latest.length.should.eq(1)
+  })
+
+  it('includes one release with the `nightly` npm dist tag', () => {
+    const nightly = releases.filter(release => release.npm_dist_tags.includes('nightly'))
+    nightly.length.should.eq(1)
   })
 
   it('includes npm_package_name prop to indicate npm publish status', () => {
@@ -71,6 +76,11 @@ describe('electron-releases', () => {
     const npmReleasesOfElectron = releases.filter(release => release.npm_package_name === 'electron')
     npmReleasesOfElectron.length.should.be.above(0)
     npmReleasesOfElectron.every(release => semver.gte(release.version, '1.3.1')).should.eq(true)
+  })
+
+  it('sets `electron-nightly` as `npm_package_name` for nightly releases', () => {
+    const npmReleasesOfElectronNightly = releases.filter(release => release.npm_package_name === 'electron-nightly')
+    npmReleasesOfElectronNightly.length.should.be.above(0)
   })
 
   it('sets `electron-prebuilt` as `npm_package_name` for releases <1.3.1', () => {


### PR DESCRIPTION
Pull information from new `electron-nightly` package and populate `npmDistTaggedVersions` with the  latest nightly.  Also correctly indicate that this version is from the `electron-nightly` package in metadata. 

```
{ '4.0.1': [ 'latest', '4-0-x' ],
  '4.0.0-beta.11': [ 'beta', 'beta-4-0-x' ],
  '2.1.0-unsupported.20180809': [ 'unsupported' ],
  '1.8.8': [ '1-8-x' ],
  '1.7.16': [ '1-7-x' ],
  '3.0.14': [ '3-0-x' ],
  '2.0.16': [ '2-0-x' ],
  '3.1.0-beta.5': [ 'beta-3-1-x' ],
  '3.1.0': [ '3-1-x' ],
  '5.0.0-nightly.20190107': [ 'nightly' ] } <= NEW ADDITION
```

Precursor to correctly displaying the latest nightly on the website.

/c @BinaryMuse 