### PR TITLE
chore: throw descriptive error when expected tag can't be found

### DIFF
--- a/script/collect.js
+++ b/script/collect.js
@@ -44,14 +44,13 @@ async function main () {
   console.log('fetching npm dist-tags')
   const distTags = npmElectronData.body['dist-tags']
 
-  const npmDistTaggedVersions = Object.keys(distTags)
-    .reduce((acc, key) => {
-      if (!key.match(/nightly/)) {
-        if (!acc[distTags[key]]) {
-          acc[distTags[key]] = [key]
-        } else {
-          acc[distTags[key]].push(key)
-        }
+  const npmDistTaggedVersions = Object.entries(distTags)
+    .reduce((acc, tagAndVersion) => {
+      const [ tag, version ] = tagAndVersion
+      if (!tag.includes('nightly')) {
+        let o = acc[version]
+        if (!o) acc[version] = o = []
+        o.push(tag)
       }
       return acc
     }, {})
@@ -124,7 +123,7 @@ async function main () {
   const oldBeta = old.find(hasNpmDistTag('beta')).version
   const newBeta = releases.find(hasNpmDistTag('beta')).version
   const oldNightly = old.find(hasNpmDistTag('nightly')).version
-  const newNightly = releases.find(hasNpmDistTag('nightly')).version
+  const newNightly = latestNightly
   const oldNpmCount = old.filter(release => release.npm_package_name === 'electron').length
   const newNpmCount = releases.filter(release => release.npm_package_name === 'electron').length
 
@@ -154,11 +153,8 @@ async function main () {
 
 function hasNpmDistTag (tag) {
   return function (release) {
-    if (!release.npm_dist_tags) {
-      return false
-    }
-
-    return release.npm_dist_tags.includes(tag)
+    const tags = release.npm_dist_tags
+    return tags && tags.includes(tag)
   }
 }
 

--- a/script/collect.js
+++ b/script/collect.js
@@ -118,11 +118,11 @@ async function main () {
       delete release.npm_dist_tag
     }
   })
-  const oldLatest = old.find(hasNpmDistTag('latest')).version
-  const newLatest = releases.find(hasNpmDistTag('latest')).version
-  const oldBeta = old.find(hasNpmDistTag('beta')).version
-  const newBeta = releases.find(hasNpmDistTag('beta')).version
-  const oldNightly = old.find(hasNpmDistTag('nightly')).version
+  const oldLatest = (old.find(hasNpmDistTag('latest')) || {}).version
+  const newLatest = (releases.find(hasNpmDistTag('latest')) || {}).version
+  const oldBeta = (old.find(hasNpmDistTag('beta')) || {}).version
+  const newBeta = (releases.find(hasNpmDistTag('beta')) || {}).version
+  const oldNightly = (old.find(hasNpmDistTag('nightly')) || {}).version
   const newNightly = latestNightly
   const oldNpmCount = old.filter(release => release.npm_package_name === 'electron').length
   const newNpmCount = releases.filter(release => release.npm_package_name === 'electron').length


### PR DESCRIPTION
"Fixes" #37 for some definition of fix.

As per discussion with @BinaryMuse below, we _want_ the script to crash if expected tags can't be found, so that if there's an error upstream, `electron/releases` doesn't compound the error by removing releases from its data.

`script/collect.js` reads from the local `index.json`, from npm, from `electron/electron`, and from `electron/nightlies`. This PR changes the code s.t. if an expected tag can't be found, the script will throw an error explaining what tag was expected and which source didn't have the tag.

PR also has minor cleanups in related code:
  * Avoid redundant property lookups
  * Replace a tag regexp with a substring search

CC @codebytere @BinaryMuse 