### PR TITLE
chore: update releases data every six hours

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,5 +1,5 @@
 workflow "Update and release" {
-  on = "schedule(0 * * * *)"
+  on = "schedule(0 */6 * * *)"
   resolves = ["Update data and release"]
 }
 


### PR DESCRIPTION
Currently, we update the releases data every hour, and bail on the release if nothing has changed. However, since download counts are included in the data, we're basically guaranteed a new minor version of the package every single time we check. Since the Dependabot integration for `electron/electronjs.org` only catches every few versions of this package anyway, I suggest that we modify the schedule so that we publish four times a day instead of 24 times a day. I think this gives us a good balance of up-to-date release info on the website (no more than ~half a day old) without publishing more than 150 new minor versions of `electron-releases` every week.

💭 @electron/wg-website?