### PR TITLE
fix: unique heading slugs for release notes HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1297,6 +1297,26 @@
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.0.0"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "dev": true,
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "dev": true,
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        }
       }
     },
     "mdast-util-to-hast": {
@@ -1316,7 +1336,33 @@
         "unist-util-position": "^3.0.0",
         "unist-util-visit": "^1.1.0",
         "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "dev": true,
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "dev": true,
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        }
       }
+    },
+    "mdast-util-to-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+      "dev": true
     },
     "mdurl": {
       "version": "1.0.1",
@@ -1595,6 +1641,26 @@
         "hast-util-has-property": "^1.0.0",
         "hast-util-is-element": "^1.0.0",
         "unist-util-visit": "^1.1.0"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "dev": true,
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "dev": true,
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        }
       }
     },
     "rehype-highlight": {
@@ -1606,6 +1672,26 @@
         "hast-util-to-text": "^1.0.0",
         "lowlight": "^1.10.0",
         "unist-util-visit": "^1.1.0"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "dev": true,
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "dev": true,
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        }
       }
     },
     "rehype-raw": {
@@ -1628,6 +1714,26 @@
         "hast-util-is-element": "^1.0.0",
         "hast-util-to-string": "^1.0.0",
         "unist-util-visit": "^1.1.0"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "dev": true,
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "dev": true,
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        }
       }
     },
     "rehype-stringify": {
@@ -1648,6 +1754,26 @@
       "requires": {
         "gemoji": "^4.0.0",
         "unist-util-visit": "^1.0.0"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "dev": true,
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "dev": true,
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        }
       }
     },
     "remark-parse": {
@@ -1930,6 +2056,26 @@
       "dev": true,
       "requires": {
         "unist-util-visit": "^1.1.0"
+      },
+      "dependencies": {
+        "unist-util-visit": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
+          "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+          "dev": true,
+          "requires": {
+            "unist-util-visit-parents": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
+          "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+          "dev": true,
+          "requires": {
+            "unist-util-is": "^3.0.0"
+          }
+        }
       }
     },
     "unist-util-stringify-position": {
@@ -1942,21 +2088,40 @@
       }
     },
     "unist-util-visit": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-      "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
       "dev": true,
       "requires": {
-        "unist-util-visit-parents": "^2.0.0"
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+          "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+          "dev": true
+        }
       }
     },
     "unist-util-visit-parents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-      "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
       "dev": true,
       "requires": {
-        "unist-util-is": "^3.0.0"
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0"
+      },
+      "dependencies": {
+        "unist-util-is": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+          "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+          "dev": true
+        }
       }
     },
     "universal-user-agent": {

--- a/package.json
+++ b/package.json
@@ -11,16 +11,18 @@
     "check-for-leaks": "^1.2.1",
     "dotenv-safe": "^8.2.0",
     "flat": "^5.0.2",
+    "github-slugger": "^1.3.0",
     "got": "^11.8.0",
     "hubdown": "^2.6.0",
     "json-to-markdown-table": "^1.0.0",
-    "lodash": "^4.17.20",
     "make-promises-safe": "^1.1.0",
+    "mdast-util-to-string": "^2.0.0",
     "mocha": "^8.2.0",
     "parse-link-header": "^1.0.1",
     "platform-utils": "^1.2.0",
     "prettier": "^2.1.2",
-    "semver": "^7.3.2"
+    "semver": "^7.3.2",
+    "unist-util-visit": "^2.0.3"
   },
   "scripts": {
     "build": "npm run collect && npm run lite && npm run update-readme",

--- a/script/collect.js
+++ b/script/collect.js
@@ -13,6 +13,9 @@ const { Octokit } = require('@octokit/rest')
 const got = require('got')
 const parseLinkHeader = require('parse-link-header')
 const { getPlatformFromFilename } = require('platform-utils')
+const visit = require('unist-util-visit');
+const toString = require('mdast-util-to-string');
+const GitHubSlugger = require('github-slugger');
 
 // `electron` was once a different module on npm. prior to 1.3.1 it was
 // published as `electron-prebuilt`
@@ -153,7 +156,7 @@ async function main() {
     const newRelease = releases.find(
       (release) => release.version === oldRelease.version
     )
-    return !newRelease || newRelease.body !== oldRelease.body
+    return !newRelease || newRelease.body_html !== oldRelease.body_html
   })
 
   if (
@@ -181,22 +184,40 @@ const findVersionForTag = (releases, tag, source) => {
   throw new Error(`No release with tag '${tag}' found in ${source}!`)
 }
 
+/**
+ * Processes the release notes into HTML using hubdown.
+ * @param {*} release 
+ * @returns 
+ */
 async function processRelease(release) {
   release.version = release.tag_name.substring(1)
-  release.body = release.body
 
-    // turn PR references like #123 into hyperlinks
+  // turn PR references like #123 into hyperlinks
+  release.body = release.body
     .replace(
       / #(\d+)/gm,
       ' <a href="https://github.com/electron/electron/pull/$1">#$1</a>'
     )
 
-    // adjust heading levels (h2 becomes h3, etc)
-    .replace(/^#### /gm, '##### ')
-    .replace(/^### /gm, '#### ')
-    .replace(/^## /gm, '### ')
+  const slugger = new GitHubSlugger()
 
-  const parsed = await hubdown(release.body)
+  /**
+   * Custom remark plugin to set unique heading IDs based on the release version.
+   * Do this so that multiple release notes can be listed in the same web page
+   * while having identical headings.
+   */  
+  const headingSlugs = () => (tree) => {
+    visit(tree, 'heading', (node) => {
+      node.data = node.data || {}
+      node.data.hProperties = node.data.hProperties || {}
+      node.data.hProperties.id = slugger.slug(`${toString(node)} ${release.version}`)
+    })
+    return tree
+  }
+
+  const parsed = await hubdown(release.body, {
+    runBefore: [headingSlugs]
+  })
   release.body_html = parsed.content
 
   return release

--- a/script/collect.js
+++ b/script/collect.js
@@ -199,6 +199,12 @@ async function processRelease(release) {
       ' <a href="https://github.com/electron/electron/pull/$1">#$1</a>'
     )
 
+  // remove top-level heading
+  release.body = release.body
+    .replace(
+      /^# Release Notes for.*/gm,
+      ''
+    )
   const slugger = new GitHubSlugger()
 
   /**


### PR DESCRIPTION
Changes the `collect` script to ensure unique IDs for each heading. Adds a remark plugin that short-circuits `rehype-slug` and adds the release's version number as a suffix.

Note: I didn't actually run the `collect` script because it will change a lot in the 100MB JSON file we export. Can wait until the next scheduled roll.