### PR TITLE
fix: use non-ESM mdast-util-to-string version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1357,9 +1357,9 @@
       }
     },
     "mdast-util-to-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
-      "integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
+      "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
       "dev": true
     },
     "mdurl": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "hubdown": "^2.6.0",
     "json-to-markdown-table": "^1.0.0",
     "make-promises-safe": "^5.1.0",
-    "mdast-util-to-string": "^3.1.0",
+    "mdast-util-to-string": "^2.0.0",
     "mocha": "^8.2.0",
     "parse-link-header": "^1.0.1",
     "platform-utils": "^1.2.0",


### PR DESCRIPTION
Refs https://github.com/electron/releases/pull/96

v3.1.0 of `mdast-util-to-string` is ESM which broke releases. Downgrade to fix.