### PR TITLE
build: add support for alpha releases

### DIFF
--- a/script/collect.js
+++ b/script/collect.js
@@ -102,7 +102,7 @@ async function main() {
       )
       if (deps) release.deps = deps
 
-      // apply dist tags from npm (usually `latest`, `beta` or `nightly`)
+      // apply dist tags from npm (usually `latest`, `alpha`, `beta` or `nightly`)
       release.npm_dist_tags = npmDistTaggedVersions[release.version] || []
 
       if (release.assets) {
@@ -142,7 +142,7 @@ async function main() {
   })
 
   let tagsChanged
-  for (const tag of ['latest', 'beta', 'nightly']) {
+  for (const tag of ['latest', 'beta', 'alpha', 'nightly']) {
     const oldVersion = findVersionForTag(old, tag, 'index.json')
     const newVersion = findVersionForTag(
       releases,

--- a/test/index.js
+++ b/test/index.js
@@ -51,6 +51,13 @@ describe('electron-releases', () => {
     releasesWithVersionData.length.should.be.above(154)
   })
 
+  it('includes one release with the `alpha` npm dist tag', () => {
+    const alpha = releases.filter((release) =>
+      release.npm_dist_tags.includes('alpha')
+    )
+    alpha.length.should.eq(1)
+  })
+
   it('includes one release with the `beta` npm dist tag', () => {
     const beta = releases.filter((release) =>
       release.npm_dist_tags.includes('beta')


### PR DESCRIPTION
Modifies the collect script and tests to support/check for alpha releases.

_Note: An "alpha" tag must be added to npm dist-tags in order to pass tests: https://docs.npmjs.com/cli/v7/commands/npm-dist-tag_